### PR TITLE
Clean up includes, fix a dangling pointer warning

### DIFF
--- a/include/modules/new_config.hpp
+++ b/include/modules/new_config.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
 int new_config(const std::vector<std::string> &deps);

--- a/include/modules/validator.hpp
+++ b/include/modules/validator.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "toml++/toml.hpp"
-#include "config.hpp"
+#include "utils/config.hpp"
+
 #include <string>
 #include <vector>
 

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -3,7 +3,8 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include "toml++/toml.hpp"
+
+#include <toml++/toml.hpp>
 
 class Config {
 private: 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,16 +1,16 @@
-#include "new_config.hpp"
-#include "validator.hpp"
-#include "settings.hpp"
-#include "symlinks.hpp"
-#include "install.hpp"
-#include "context.hpp"
-#include "remove.hpp"
-#include "config.hpp"
-#include "CLI/CLI.hpp"
-#include "list.hpp"
+#include <CLI/CLI.hpp>
 #include <iostream>
-#include <unistd.h>
 #include <string>
+#include <unistd.h>
+
+#include "context.hpp"
+#include "modules/install.hpp"
+#include "modules/list.hpp"
+#include "modules/new_config.hpp"
+#include "modules/remove.hpp"
+#include "modules/validator.hpp"
+#include "utils/config.hpp"
+#include "utils/symlinks.hpp"
 
 int main(int argc, char** argv) {
   if (!getuid()) {

--- a/src/modules/install.cpp
+++ b/src/modules/install.cpp
@@ -1,16 +1,15 @@
-#include "install.hpp"
-
-#include "git2.h"
-#include "config.hpp"
-#include "context.hpp"
-#include "settings.hpp"
-#include "validator.hpp"
-#include "format_check.hpp"
-#include <string_view>
-#include <filesystem>
-#include <iostream>
 #include <cstdio>
+#include <iostream>
 #include <string>
+
+#include <git2.h>
+
+#include "context.hpp"
+#include "modules/install.hpp"
+#include "modules/validator.hpp"
+#include "settings.hpp"
+#include "utils/config.hpp"
+#include "utils/format_check.hpp"
 
 int install() {
   if (!is_valid_url()) {
@@ -21,12 +20,10 @@ int install() {
   size_t last_slash = ctx->name.find_last_of("/");
   if (last_slash == std::string::npos) return 1;
 
-  std::string_view name_view = ctx->name.substr(last_slash + 1);
+  std::string name = ctx->name.substr(last_slash + 1);
 
-  if (name_view.ends_with(".git"))
-    name_view.remove_suffix(4);
-
-  std::string name = std::string(name_view);
+  if (name.size() >= 4 && name.compare(name.size() - 4, 4, ".git") == 0)
+    name.erase(name.size() - 4);
 
   git_libgit2_init();
 

--- a/src/modules/list.cpp
+++ b/src/modules/list.cpp
@@ -1,13 +1,11 @@
-#include "list.hpp"
-#include "config.hpp"
-#include "context.hpp"
-#include "settings.hpp"
-#include "toml++/toml.hpp"
-#include <filesystem>
-#include <iostream>
 #include <cstdlib>
+#include <filesystem>
 #include <string>
-#include <format>
+
+#include "context.hpp"
+#include "modules/list.hpp"
+#include "settings.hpp"
+#include "utils/config.hpp"
 
 void list() {
   toml::table config;

--- a/src/modules/new_config.cpp
+++ b/src/modules/new_config.cpp
@@ -1,13 +1,15 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdlib.h>
+#include <string>
+#include <vector>
+
 #include <toml++/toml.hpp>
+
 #include "context.hpp"
 #include "settings.hpp"
-#include <filesystem>
-#include <stdlib.h>
-#include <iostream>
-#include <cstdlib>
-#include <fstream>
-#include <vector>
-#include <string>
 
 int new_config(const std::vector<std::string> &deps) {
   std::string path = dotfiles_path + ctx->name;

--- a/src/modules/remove.cpp
+++ b/src/modules/remove.cpp
@@ -1,8 +1,9 @@
-#include "settings.hpp"
-#include "context.hpp"
 #include <filesystem>
 #include <iostream>
 #include <string>
+
+#include "context.hpp"
+#include "settings.hpp"
 
 int remove_config() {
   std::string path = dotfiles_path + ctx->name;

--- a/src/modules/validator.cpp
+++ b/src/modules/validator.cpp
@@ -1,11 +1,10 @@
-#include "toml++/toml.hpp"
-#include "config.hpp"
-#include <unordered_map>
 #include <filesystem>
 #include <iostream>
-#include <vector>
-#include <format>
 #include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "utils/config.hpp"
 
 struct ValidationResult {
   enum class Type { Warning, Error };

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -1,14 +1,11 @@
-#include "config.hpp"
-
-#include "toml++/toml.hpp"
-#include "settings.hpp"
-#include "context.hpp"
-#include <unordered_map>
 #include <filesystem>
 #include <iostream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
+#include "settings.hpp"
+#include "utils/config.hpp"
 
 Config::Config(const std::string& name) : name_(name) {
   parse_config();

--- a/src/utils/format_check.cpp
+++ b/src/utils/format_check.cpp
@@ -1,6 +1,6 @@
-#include "context.hpp"
-#include <iostream>
 #include <string>
+
+#include "context.hpp"
 
 /* @brief Checks if the value contains `://`.
  *

--- a/src/utils/symlinks.cpp
+++ b/src/utils/symlinks.cpp
@@ -1,13 +1,13 @@
-#include "config.hpp"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "context.hpp"
 #include "settings.hpp"
-#include "toml++/toml.hpp"
-#include <unordered_map>
-#include <filesystem>
-#include <iostream>
-#include <fstream>
-#include <vector>
-#include <string>
+#include "utils/config.hpp"
 
 /* @brief Removes every active symlink from the config!
  *


### PR DESCRIPTION
- clean up the includes to be alphabetically sorted and grouped by:
  - standard libraries
  - 3rd party dependencies
  - our own headers
- fix a dangling pointer warning from clang in install.cpp