### PR TITLE
Small code style changes to improve readability, safety, & performance using modern C++ features

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,6 +36,7 @@ AlignConsecutiveShortCaseStatements:
   AlignCaseColons: false
 AlignAfterOpenBracket: AlwaysBreak
 AlignEscapedNewlines: Left
+AlignConsecutiveAssignments: Consecutive
 
 # Break
 BreakBeforeBraces: Attach

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   cmake:
@@ -83,4 +87,3 @@ jobs:
           name: dotplug-meson
           path: |
             build/dotplug
-

--- a/include/modules/validator.hpp
+++ b/include/modules/validator.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "utils/config.hpp"
-
 #include <string>
 #include <vector>
 
@@ -15,23 +13,9 @@ struct ValidationResult {
 
     std::vector<Entries> log;
 
-    inline bool has_errors() const {
-        for (const auto &e : log)
-            if (e.type == Type::Error)
-                return true;
-        return false;
-    }
-
-    inline bool has_warnings() const {
-        for (const auto &e : log)
-            if (e.type == Type::Warning)
-                return true;
-        return false;
-    }
-
-    void add_error(std::string msg);
-    void add_warning(std::string msg);
+    auto has_errors() const -> bool;
+    auto has_warnings() const -> bool;
+    auto add_error(const std::string &msg) -> void;
+    auto add_warning(const std::string &msg) -> void;
+    auto print() const -> void;
 };
-
-void print_validation(ValidationResult &result);
-ValidationResult validator(const Config &config);

--- a/include/modules/validator.hpp
+++ b/include/modules/validator.hpp
@@ -3,7 +3,8 @@
 #include <string>
 #include <vector>
 
-struct ValidationResult {
+class ValidationResult {
+public:
     enum class Type { Warning, Error };
 
     struct Entries {
@@ -11,8 +12,10 @@ struct ValidationResult {
         Type type;
     };
 
+private:
     std::vector<Entries> log;
 
+public:
     auto has_errors() const -> bool;
     auto has_warnings() const -> bool;
     auto add_error(const std::string &msg) -> void;

--- a/include/modules/validator.hpp
+++ b/include/modules/validator.hpp
@@ -5,15 +5,20 @@
 
 class ValidationResult {
 public:
-    enum class Type { Warning, Error };
+    struct LogEntry {
+        enum class Type { Warning, Error };
 
-    struct Entries {
         std::string message;
         Type type;
+
+        // explicit constructor needed for usage with std::vector::emplace_back
+        LogEntry(const std::string &msg, const Type t)
+            : message{msg},
+              type{t} {}
     };
 
 private:
-    std::vector<Entries> log;
+    std::vector<LogEntry> log;
 
 public:
     auto has_errors() const -> bool;

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -3,6 +3,8 @@
 #include <cstdlib>
 #include <string>
 
-inline std::string config_path = std::string(std::getenv("HOME")) + CONFIG_PATH;
-inline std::string dotfiles_path = std::string(std::getenv("HOME")) + DOTFILES_PATH;
-inline std::string destination_path = std::string(std::getenv("HOME")) + DESTINATION_PATH;
+// clang-format off
+inline const auto home = std::string{getenv("HOME")},
+				  config_path = home + CONFIG_PATH,
+                  dotfiles_path = home + DOTFILES_PATH,
+                  destination_path = home + DESTINATION_PATH;

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -21,13 +21,12 @@ public:
     // get data from a specific dependency
     auto get_dependency(const std::string &dep_name) const -> std::unordered_map<std::string, std::string>;
 
-    auto name() const -> const std::string & { return name_; }
-    auto config() const -> const toml::table & { return config_; }
-
-    // formerly a free function called print_config(const Config &, ...)
     auto print(const std::string prefix = "") const -> void;
+    auto validate() const -> ValidationResult;
 
-	auto validate() const -> ValidationResult;
+    // getter methods
+    auto name() const { return name_; }
+    auto config() const { return config_; }
 
 private:
     auto parse_config() -> void;

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -7,18 +7,24 @@
 #include <toml++/toml.hpp>
 
 class Config {
-private:
-    void parse_config();
-
-public:
     std::string name_;
     toml::table config_;
 
+public:
     Config(const std::string &name);
 
-    std::vector<std::string> get_dependencies() const; // get all dependencies
-    std::unordered_map<std::string, std::string>
-    get_dependency(const std::string &dep_name) const; // get data from a specific dependency
-};
+    // get all dependencies
+    auto get_dependencies() const -> std::vector<std::string>;
 
-void print_config(const Config &config, const std::string prefix = "");
+    // get data from a specific dependency
+    auto get_dependency(const std::string &dep_name) const -> std::unordered_map<std::string, std::string>;
+
+    auto name() const -> const std::string & { return name_; }
+    auto config() const -> const toml::table & { return config_; }
+
+    // formerly a free function called print_config(const Config &, ...)
+    auto print(const std::string prefix = "") const -> void;
+
+private:
+    auto parse_config() -> void;
+};

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -6,6 +6,8 @@
 
 #include <toml++/toml.hpp>
 
+#include "modules/validator.hpp"
+
 class Config {
     std::string name_;
     toml::table config_;
@@ -24,6 +26,8 @@ public:
 
     // formerly a free function called print_config(const Config &, ...)
     auto print(const std::string prefix = "") const -> void;
+
+	auto validate() const -> ValidationResult;
 
 private:
     auto parse_config() -> void;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,9 +89,8 @@ int main(int argc, char **argv) {
 
     else if (config_cmd->parsed()) {
         if (validate_cmd->parsed()) {
-            Config config_ = Config(value);
-            ValidationResult validation_result = validator(config_.name());
-            print_validation(validation_result);
+            const auto validation_result = Config{value}.validate();
+            validation_result.print();
         } else if (remove_cmd->parsed())
             remove_config();
         else if (show_cmd->parsed())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,8 +15,8 @@
 
 int main(int argc, char **argv) {
     if (!getuid()) {
-        std::cout << "Using `sudo` is prohibited.\n";
-        return 1;
+        std::cerr << "Using `sudo` is prohibited.\n";
+        return EXIT_FAILURE;
     }
 
     CLI::App app{"Dotplug is a easy-to-use dotfile manager for linux."};
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
 
     std::string value; // stuff like names or links.
     auto dependencies = std::vector<std::string>{};
-    bool forced = false;
+    bool forced       = false;
 
     auto add_force_flag = [&](CLI::App *cmd) {
         cmd->add_flag("-f,--force", forced, "Force the action and ignore warnings (CAUTION!)");
@@ -50,11 +50,11 @@ int main(int argc, char **argv) {
     auto config_cmd = app.add_subcommand("config", "Do stuff with your configuration.");
     config_cmd->add_option("name", value, "The name of the configuration.")->required();
 
-    auto validate_cmd = config_cmd->add_subcommand("validate", "Check if the configuration config is valid.");
-    auto disable_cmd = config_cmd->add_subcommand("disable", "Disable the current configuration.");
-    auto remove_cmd = config_cmd->add_subcommand("remove", "Remove a dotfile configuration.");
-    auto apply_cmd = config_cmd->add_subcommand("apply", "Apply a dotfile configuration.");
-    auto show_cmd = config_cmd->add_subcommand("show", "Shows a specific configuration.");
+    auto validate_cmd = config_cmd->add_subcommand("validate", "Check if the configuration config is valid."),
+         disable_cmd  = config_cmd->add_subcommand("disable", "Disable the current configuration."),
+         remove_cmd   = config_cmd->add_subcommand("remove", "Remove a dotfile configuration."),
+         apply_cmd    = config_cmd->add_subcommand("apply", "Apply a dotfile configuration."),
+         show_cmd     = config_cmd->add_subcommand("show", "Shows a specific configuration.");
 
     // auto disable_cmd = app.add_subcommand("disable", "Disables your current
     // configuration.");
@@ -79,28 +79,31 @@ int main(int argc, char **argv) {
     if (!value.empty())
         ctx->name = value;
 
-    // actions
-    if (list_cmd->parsed())
-        list();
-    else if (init_cmd->parsed())
-        new_config(dependencies);
-    else if (install_cmd->parsed())
-        install();
+    try {
+        // actions
+        if (list_cmd->parsed())
+            list();
+        else if (init_cmd->parsed())
+            new_config(dependencies);
+        else if (install_cmd->parsed())
+            install();
 
-    else if (config_cmd->parsed()) {
-        if (validate_cmd->parsed()) {
-            Config{value}.validate().print();
-        } else if (remove_cmd->parsed())
-            remove_config();
-        else if (show_cmd->parsed())
-            list();
-        else if (apply_cmd->parsed())
-            apply();
-        else if (disable_cmd->parsed())
-            remove_all_symlinks();
-        else
-            list();
+        else if (config_cmd->parsed()) {
+            if (validate_cmd->parsed())
+                Config{value}.validate().print();
+            else if (remove_cmd->parsed())
+                remove_config();
+            else if (show_cmd->parsed())
+                list();
+            else if (apply_cmd->parsed())
+                apply();
+            else if (disable_cmd->parsed())
+                remove_all_symlinks();
+            else
+                list();
+        }
+    } catch (const std::exception &e) {
+        std::cerr << argv[0] << ": " << e.what() << '\n';
+        return EXIT_FAILURE;
     }
-
-    return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 
 int main(int argc, char **argv) {
     if (!getuid()) {
-        std::cout << "Using `sudo` is prohibited." << std::endl;
+        std::cout << "Using `sudo` is prohibited.\n";
         return 1;
     }
 
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
     app.require_subcommand();
 
     std::string value; // stuff like names or links.
-    std::vector<std::string> dependencies;
+    auto dependencies = std::vector<std::string>{};
     bool forced = false;
 
     auto add_force_flag = [&](CLI::App *cmd) {
@@ -89,8 +89,7 @@ int main(int argc, char **argv) {
 
     else if (config_cmd->parsed()) {
         if (validate_cmd->parsed()) {
-            const auto validation_result = Config{value}.validate();
-            validation_result.print();
+            Config{value}.validate().print();
         } else if (remove_cmd->parsed())
             remove_config();
         else if (show_cmd->parsed())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
     else if (config_cmd->parsed()) {
         if (validate_cmd->parsed()) {
             Config config_ = Config(value);
-            ValidationResult validation_result = validator(config_.name_);
+            ValidationResult validation_result = validator(config_.name());
             print_validation(validation_result);
         } else if (remove_cmd->parsed())
             remove_config();

--- a/src/modules/apply.cpp
+++ b/src/modules/apply.cpp
@@ -17,25 +17,23 @@ int apply() {
 
     const Config config{ctx->name};
 
-    for (std::string &dep_name : config.get_dependencies()) {
+    for (const auto &dep_name : config.get_dependencies()) {
         const auto dep = config.get_dependency(dep_name);
         const auto src = dep.at("source"), dst = dep.at("destination");
 
         if (!fs::exists(src)) {
-            std::cerr << "[ERROR] The source of " << dep_name << " couldn't be found!" << std::endl;
+            std::cerr << "[ERROR] The source of " << dep_name << " couldn't be found!\n";
             return 1;
         }
 
         if (dst.empty()) {
-            std::cerr << "[ERROR] Couldn't find the destination of " << dep_name << std::endl;
+            std::cerr << "[ERROR] Couldn't find the destination of " << dep_name << '\n';
             return 1;
         }
 
         fs::create_directory_symlink(src, dst);
     }
 
-    std::ofstream current{config_path + "current"};
-    current << (dotfiles_path + config.name() + "/config.toml");
-
+    std::ofstream{config_path + "current"} << (dotfiles_path + config.name() + "/config.toml");
     return 0;
 }

--- a/src/modules/apply.cpp
+++ b/src/modules/apply.cpp
@@ -9,34 +9,33 @@
 #include "utils/config.hpp"
 #include "utils/symlinks.hpp"
 
+namespace fs = std::filesystem;
+
 int apply() {
-    if (std::filesystem::exists(config_path + "current"))
+    if (fs::exists(config_path + "current"))
         remove_all_symlinks();
 
-    const Config config = Config(ctx->name);
+    const Config config{ctx->name};
 
     for (std::string &dep_name : config.get_dependencies()) {
-        std::unordered_map<std::string, std::string> dep = config.get_dependency(dep_name);
+        const auto dep = config.get_dependency(dep_name);
+        const auto src = dep.at("source"), dst = dep.at("destination");
 
-        if (!std::filesystem::exists(dep["source"])) {
+        if (!fs::exists(src)) {
             std::cerr << "[ERROR] The source of " << dep_name << " couldn't be found!" << std::endl;
             return 1;
         }
-        if (dep["destination"].empty()) {
+
+        if (dst.empty()) {
             std::cerr << "[ERROR] Couldn't find the destination of " << dep_name << std::endl;
             return 1;
         }
 
-        std::error_code err;
-        std::filesystem::create_directory_symlink(dep["source"], dep["destination"], err);
-
-        if (err)
-            throw std::runtime_error(err.message());
+        fs::create_directory_symlink(src, dst);
     }
 
-    std::fstream current(config_path + "current");
-    current << (dotfiles_path + config.name_ + "/config.toml");
-    current.close();
+    std::ofstream current{config_path + "current"};
+    current << (dotfiles_path + config.name() + "/config.toml");
 
     return 0;
 }

--- a/src/modules/install.cpp
+++ b/src/modules/install.cpp
@@ -54,10 +54,10 @@ int install() {
         return 0;
 
     const Config config = Config(name);
-    ValidationResult validation_result = validator(config);
+    const auto validation_result = config.validate();
 
     if (validation_result.has_errors())
-        print_validation(validation_result);
+        validation_result.print();
 
     return 0;
 }

--- a/src/modules/install.cpp
+++ b/src/modules/install.cpp
@@ -13,7 +13,7 @@
 
 int install() {
     if (!is_valid_url()) {
-        std::cout << "The provided value is not a URL!\n";
+        std::cerr << "The provided value is not a URL!\n";
         return 1;
     }
 
@@ -26,19 +26,20 @@ int install() {
     if (name.size() >= 4 && name.compare(name.size() - 4, 4, ".git") == 0)
         name.erase(name.size() - 4);
 
+    // all this does is a `git clone`... we don't need the entirety of libgit2...
+    // todo: remove libgit2, just popen("git clone ...") instead
     git_libgit2_init();
 
-    const git_error *err = git_error_last();
-    if (err && std::string(err->message) != "no error") {
+    const auto err = git_error_last();
+    if (err && std::string_view{err->message} != "no error") {
         std::cerr << "Something failed during the git initialization.\n" << err->message << '\n';
         return 1;
     }
 
-    std::string clone_path = dotfiles_path + name;
-    git_repository *repo_ptr = nullptr;
-    const int clone_return = git_clone(&repo_ptr, ctx->name.c_str(), clone_path.c_str(), NULL);
+    const auto clone_path = dotfiles_path + name;
+    git_repository *repo_ptr{};
 
-    if (clone_return != 0) {
+    if (git_clone(&repo_ptr, ctx->name.c_str(), clone_path.c_str(), NULL)) {
         std::cerr << "Something wen't wrong during the cloning process.\n" << git_error_last()->message << '\n';
         return 1;
     }

--- a/src/modules/install.cpp
+++ b/src/modules/install.cpp
@@ -13,15 +13,15 @@
 
 int install() {
     if (!is_valid_url()) {
-        std::cout << "The provided value is not a URL!" << std::endl;
+        std::cout << "The provided value is not a URL!\n";
         return 1;
     }
 
-    size_t last_slash = ctx->name.find_last_of("/");
+    const auto last_slash = ctx->name.find_last_of("/");
     if (last_slash == std::string::npos)
         return 1;
 
-    std::string name = ctx->name.substr(last_slash + 1);
+    auto name = ctx->name.substr(last_slash + 1);
 
     if (name.size() >= 4 && name.compare(name.size() - 4, 4, ".git") == 0)
         name.erase(name.size() - 4);
@@ -30,7 +30,7 @@ int install() {
 
     const git_error *err = git_error_last();
     if (err && std::string(err->message) != "no error") {
-        std::cerr << "Something failed during the git initialization.\n" << err->message << std::endl;
+        std::cerr << "Something failed during the git initialization.\n" << err->message << '\n';
         return 1;
     }
 
@@ -39,7 +39,7 @@ int install() {
     const int clone_return = git_clone(&repo_ptr, ctx->name.c_str(), clone_path.c_str(), NULL);
 
     if (clone_return != 0) {
-        std::cerr << "Something wen't wrong during the cloning process.\n" << git_error_last()->message << std::endl;
+        std::cerr << "Something wen't wrong during the cloning process.\n" << git_error_last()->message << '\n';
         return 1;
     }
 
@@ -53,7 +53,7 @@ int install() {
     if (validate_choice.empty() || validate_choice == "n" || validate_choice == "N")
         return 0;
 
-    const Config config = Config(name);
+    const Config config{name};
     const auto validation_result = config.validate();
 
     if (validation_result.has_errors())

--- a/src/modules/list.cpp
+++ b/src/modules/list.cpp
@@ -7,19 +7,15 @@
 #include "settings.hpp"
 #include "utils/config.hpp"
 
-void list() {
-    toml::table config;
+namespace fs = std::filesystem;
 
+void list() {
     if (!ctx->name.empty()) {
-        Config config_ = Config(ctx->name);
-        print_config(config_);
+        Config{ctx->name}.print();
         return;
     }
 
     size_t i = 1;
-    for (const auto &entry : std::filesystem::directory_iterator(std::filesystem::path(dotfiles_path))) {
-        Config config_ = Config(entry.path().filename().string());
-        print_config(config_, std::to_string(i));
-        ++i;
-    }
+    for (const auto &entry : fs::directory_iterator{dotfiles_path})
+        Config{entry.path().filename().string()}.print(std::to_string(i++));
 }

--- a/src/modules/remove.cpp
+++ b/src/modules/remove.cpp
@@ -23,6 +23,6 @@ int remove_config() {
             return 0;
     }
 
-	fs::remove_all(path);
+    fs::remove_all(path);
     return 0;
 }

--- a/src/modules/remove.cpp
+++ b/src/modules/remove.cpp
@@ -5,11 +5,13 @@
 #include "context.hpp"
 #include "settings.hpp"
 
-int remove_config() {
-    std::string path = dotfiles_path + ctx->name;
+namespace fs = std::filesystem;
 
-    if (!std::filesystem::exists(path)) {
-        std::cout << "The config doesn't exist." << std::endl;
+int remove_config() {
+    const auto path = dotfiles_path + ctx->name;
+
+    if (!fs::exists(path)) {
+        std::cout << "The config doesn't exist.\n";
         return 1;
     }
 
@@ -21,11 +23,6 @@ int remove_config() {
             return 0;
     }
 
-    std::error_code err;
-    if (!std::filesystem::remove_all(path, err)) {
-        std::cout << "Oopsies, a error happened :( \n" << err.message() << std::endl;
-        return 1;
-    }
-
+	fs::remove_all(path);
     return 0;
 }

--- a/src/modules/validator.cpp
+++ b/src/modules/validator.cpp
@@ -27,7 +27,7 @@ auto ValidationResult::add_warning(const std::string &msg) -> void {
 
 auto ValidationResult::print() const -> void {
     if (log.empty())
-        std::cout << "Everything is fine with the configuration." << std::endl;
+        std::cout << "Everything is fine with the configuration.\n";
     for (const auto &e : log)
         std::cout << (e.type == ValidationResult::Type::Error ? "[ERROR] " : "[WARNING] ") << e.message << "\n";
     return;

--- a/src/modules/validator.cpp
+++ b/src/modules/validator.cpp
@@ -16,8 +16,8 @@ struct ValidationResult {
 
     std::vector<Entries> log;
 
-    void add_error(std::string msg) { log.push_back({msg, Type::Error}); }
-    void add_warning(std::string msg) { log.push_back({msg, Type::Warning}); }
+    void add_error(const std::string &msg) { log.emplace_back(msg, Type::Error); }
+    void add_warning(const std::string &msg) { log.emplace_back(msg, Type::Warning); }
 };
 
 void print_validation(ValidationResult &result) {
@@ -31,7 +31,7 @@ void print_validation(ValidationResult &result) {
 ValidationResult validator(const Config &config) {
     ValidationResult output;
 
-    const std::vector<std::string> dependencies = config.get_dependencies();
+    const auto dependencies = config.get_dependencies();
 
     if (dependencies.empty()) {
         std::cout << "You need at least a single dependency" << std::endl;
@@ -39,12 +39,12 @@ ValidationResult validator(const Config &config) {
     }
 
     for (const std::string &dep : dependencies) {
-        if (!config.config_["dotplug"][dep].is_table()) {
+        if (!config.config()["dotplug"][dep].is_table()) {
             output.add_error(dep + " doesn't exist or it isn't a table");
             continue;
         }
 
-        const std::unordered_map<std::string, std::string> dep_infos = config.get_dependency(dep);
+        const auto dep_infos = config.get_dependency(dep);
 
         if (dep_infos.count("destination") && (dep_infos.at("destination").empty()))
             output.add_error("You need to add destination for " + dep);

--- a/src/modules/validator.cpp
+++ b/src/modules/validator.cpp
@@ -5,30 +5,30 @@
 
 auto ValidationResult::has_errors() const -> bool {
     for (const auto &e : log)
-        if (e.type == Type::Error)
+        if (e.type == LogEntry::Type::Error)
             return true;
     return false;
 }
 
 auto ValidationResult::has_warnings() const -> bool {
     for (const auto &e : log)
-        if (e.type == Type::Warning)
+        if (e.type == LogEntry::Type::Warning)
             return true;
     return false;
 }
 
 auto ValidationResult::add_error(const std::string &msg) -> void {
-    log.emplace_back(msg, Type::Error);
+    log.emplace_back(msg, LogEntry::Type::Error);
 }
 
 auto ValidationResult::add_warning(const std::string &msg) -> void {
-    log.emplace_back(msg, Type::Warning);
+    log.emplace_back(msg, LogEntry::Type::Warning);
 }
 
 auto ValidationResult::print() const -> void {
     if (log.empty())
         std::cout << "Everything is fine with the configuration.\n";
     for (const auto &e : log)
-        std::cout << (e.type == ValidationResult::Type::Error ? "[ERROR] " : "[WARNING] ") << e.message << "\n";
+        std::cout << (e.type == LogEntry::Type::Error ? "[ERROR] " : "[WARNING] ") << e.message << "\n";
     return;
 }

--- a/src/modules/validator.cpp
+++ b/src/modules/validator.cpp
@@ -1,59 +1,34 @@
-#include <filesystem>
 #include <iostream>
-#include <string>
-#include <unordered_map>
 #include <vector>
 
-#include "utils/config.hpp"
+#include "modules/validator.hpp"
 
-struct ValidationResult {
-    enum class Type { Warning, Error };
-
-    struct Entries {
-        std::string message;
-        Type type;
-    };
-
-    std::vector<Entries> log;
-
-    void add_error(const std::string &msg) { log.emplace_back(msg, Type::Error); }
-    void add_warning(const std::string &msg) { log.emplace_back(msg, Type::Warning); }
-};
-
-void print_validation(ValidationResult &result) {
-    if (result.log.empty())
-        std::cout << "Everything is fine with the configuration." << std::endl;
-    for (const auto &e : result.log)
-        std::cout << (e.type == ValidationResult::Type::Error ? "[ERROR] " : "[WARNING] ") << e.message << "\n";
-    return;
+auto ValidationResult::has_errors() const -> bool {
+    for (const auto &e : log)
+        if (e.type == Type::Error)
+            return true;
+    return false;
 }
 
-ValidationResult validator(const Config &config) {
-    ValidationResult output;
+auto ValidationResult::has_warnings() const -> bool {
+    for (const auto &e : log)
+        if (e.type == Type::Warning)
+            return true;
+    return false;
+}
 
-    const auto dependencies = config.get_dependencies();
+auto ValidationResult::add_error(const std::string &msg) -> void {
+    log.emplace_back(msg, Type::Error);
+}
 
-    if (dependencies.empty()) {
-        std::cout << "You need at least a single dependency" << std::endl;
-        return output;
-    }
+auto ValidationResult::add_warning(const std::string &msg) -> void {
+    log.emplace_back(msg, Type::Warning);
+}
 
-    for (const std::string &dep : dependencies) {
-        if (!config.config()["dotplug"][dep].is_table()) {
-            output.add_error(dep + " doesn't exist or it isn't a table");
-            continue;
-        }
-
-        const auto dep_infos = config.get_dependency(dep);
-
-        if (dep_infos.count("destination") && (dep_infos.at("destination").empty()))
-            output.add_error("You need to add destination for " + dep);
-
-        if (dep_infos.count("source") &&
-            (dep_infos.at("source").empty() || !std::filesystem::exists(dep_infos.at("source")))) {
-            output.add_error("Couldn't find source of " + dep);
-        }
-    }
-
-    return output;
+auto ValidationResult::print() const -> void {
+    if (log.empty())
+        std::cout << "Everything is fine with the configuration." << std::endl;
+    for (const auto &e : log)
+        std::cout << (e.type == ValidationResult::Type::Error ? "[ERROR] " : "[WARNING] ") << e.message << "\n";
+    return;
 }

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -31,7 +31,7 @@ auto Config::parse_config() -> void {
 
 // Get the list of dependencies
 auto Config::get_dependencies() const -> std::vector<std::string> {
-    auto dependencies = std::vector<std::string>{};
+    auto dependencies     = std::vector<std::string>{};
     const auto deps_array = config_["dotplug"]["dependencies"].as_array();
 
     if (!deps_array || deps_array->empty())
@@ -53,7 +53,7 @@ auto Config::get_dependency(const std::string &dep_name) const -> std::unordered
     if (!config_["dotplug"][dep_name].is_table())
         throw std::runtime_error{dep_name + " doesn't exist or isn't a table"};
 
-    const auto source_node = config_["dotplug"][dep_name]["source"];
+    const auto source_node      = config_["dotplug"][dep_name]["source"];
     const auto destination_node = config_["dotplug"][dep_name]["destination"];
 
     // formatter doesn't respect existing ternary breaking, so just turn it off
@@ -75,16 +75,16 @@ auto Config::get_dependency(const std::string &dep_name) const -> std::unordered
         : (destination_path + dest_path);
     // clang-format on
 
-    output["source"] = source;
+    output["source"]      = source;
     output["destination"] = destination;
 
     return output;
 }
 
 auto Config::print(const std::string prefix) const -> void {
-    const auto name = config_["dotplug"]["name"].value_or<std::string>("Unknown Name"),
-               description = config_["dotplug"]["description"].value_or<std::string>(""),
-               author = config_["dotplug"]["author"].value_or<std::string>("");
+    const auto name         = config_["dotplug"]["name"].value_or<std::string>("Unknown Name"),
+               description  = config_["dotplug"]["description"].value_or<std::string>(""),
+               author       = config_["dotplug"]["author"].value_or<std::string>("");
     const auto dependencies = get_dependencies();
 
     std::cout << (!prefix.empty() ? "[" + prefix + "] " : "") << name << ":\n";
@@ -100,7 +100,7 @@ auto Config::print(const std::string prefix) const -> void {
 }
 
 auto Config::validate() const -> ValidationResult {
-    auto output = ValidationResult{};
+    auto output             = ValidationResult{};
     const auto dependencies = get_dependencies();
 
     if (dependencies.empty()) {
@@ -119,10 +119,8 @@ auto Config::validate() const -> ValidationResult {
         if (dep_infos.count("destination") && (dep_infos.at("destination").empty()))
             output.add_error("You need to add destination for " + dep);
 
-        if (dep_infos.count("source") &&
-            (dep_infos.at("source").empty() || !fs::exists(dep_infos.at("source")))) {
+        if (dep_infos.count("source") && (dep_infos.at("source").empty() || !fs::exists(dep_infos.at("source"))))
             output.add_error("Couldn't find source of " + dep);
-        }
     }
 
     return output;

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -104,7 +104,7 @@ auto Config::validate() const -> ValidationResult {
     const auto dependencies = get_dependencies();
 
     if (dependencies.empty()) {
-        std::cout << "You need at least a single dependency" << std::endl;
+        std::cout << "You need at least a single dependency\n";
         return output;
     }
 

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -7,64 +7,73 @@
 #include "settings.hpp"
 #include "utils/config.hpp"
 
+namespace fs = std::filesystem;
+
 Config::Config(const std::string &name)
     : name_(name) {
     parse_config();
 }
 
-void Config::parse_config() {
-    std::string path = dotfiles_path + name_ + "/config.toml";
+auto Config::parse_config() -> void {
+    const auto path = dotfiles_path + name_ + "/config.toml";
 
-    if (!std::filesystem::exists(path))
-        throw std::runtime_error("The config doesn't have a config.toml");
+    if (!fs::exists(path))
+        throw std::runtime_error{"The config doesn't have a config.toml"};
 
     try {
         config_ = toml::parse_file(path);
     } catch (const toml::parse_error &err) {
-        throw std::runtime_error("Parsing failed: \n" + std::string(err.description()));
+        throw std::runtime_error{"Parsing failed: \n" + std::string{err.description()}};
     }
 
     return;
 }
 
 // Get the list of dependencies
-std::vector<std::string> Config::get_dependencies() const {
-    std::vector<std::string> dependencies;
-
-    const auto &config_deps = config_["dotplug"]["dependencies"];
-    const auto *deps_array = config_deps.as_array();
+auto Config::get_dependencies() const -> std::vector<std::string> {
+    auto dependencies = std::vector<std::string>{};
+    const auto deps_array = config_["dotplug"]["dependencies"].as_array();
 
     if (!deps_array || deps_array->empty())
         return dependencies;
 
-    for (size_t i = 0; i < deps_array->size(); ++i) {
-        const auto &dep_node = (*deps_array)[i];
-
+    for (const auto &dep_node : *deps_array) {
         if (!dep_node.is_string())
             continue;
-        dependencies.push_back(dep_node.value<std::string>().value_or(""));
+        dependencies.emplace_back(dep_node.value_or<std::string>(""));
     }
+
     return dependencies;
 }
 
 // Get the data of a specific dependency
-std::unordered_map<std::string, std::string> Config::get_dependency(const std::string &dep_name) const {
-    std::unordered_map<std::string, std::string> output;
+auto Config::get_dependency(const std::string &dep_name) const -> std::unordered_map<std::string, std::string> {
+    auto output = std::unordered_map<std::string, std::string>{};
 
     if (!config_["dotplug"][dep_name].is_table())
-        throw std::runtime_error(dep_name + " doesn't exist or isn't a table");
+        throw std::runtime_error{dep_name + " doesn't exist or isn't a table"};
 
-    auto source_node = config_["dotplug"][dep_name]["source"];
-    auto destination_node = config_["dotplug"][dep_name]["destination"];
+    const auto source_node = config_["dotplug"][dep_name]["source"];
+    const auto destination_node = config_["dotplug"][dep_name]["destination"];
 
-    std::string source_path = (source_node || source_node.is_string()) ? source_node.value_or("") : dep_name;
-    std::string dest_path =
-        (destination_node || destination_node.is_string()) ? destination_node.value_or("") : dep_name;
+    // formatter doesn't respect existing ternary breaking, so just turn it off
+    // clang-format off
+    const auto source_path = (source_node || source_node.is_string())
+        ? source_node.value_or("")
+        : dep_name;
 
-    std::string source =
-        source_path.empty() ? dotfiles_path + name_ + "/" + dep_name : dotfiles_path + name_ + "/" + source_path;
+    const auto dest_path = (destination_node || destination_node.is_string())
+        ? destination_node.value_or("")
+        : dep_name;
 
-    std::string destination = dest_path.empty() ? destination_path + dep_name : destination_path + dest_path;
+    const auto source = source_path.empty()
+        ? (dotfiles_path + name_ + "/" + dep_name)
+        : (dotfiles_path + name_ + "/" + source_path);
+
+    const auto destination = dest_path.empty() 
+        ? (destination_path + dep_name)
+        : (destination_path + dest_path);
+    // clang-format on
 
     output["source"] = source;
     output["destination"] = destination;
@@ -72,21 +81,20 @@ std::unordered_map<std::string, std::string> Config::get_dependency(const std::s
     return output;
 }
 
-void print_config(const Config &config, const std::string prefix) {
-    std::string_view name = config.config_["dotplug"]["name"].value_or(std::string_view("Unknown Name"));
-    std::string_view description = config.config_["dotplug"]["description"].value_or(std::string_view(""));
-    std::string_view author = config.config_["dotplug"]["author"].value_or(std::string_view(""));
-    std::vector<std::string> dependencies = config.get_dependencies();
+auto Config::print(const std::string prefix) const -> void {
+    const auto name = config_["dotplug"]["name"].value_or<std::string>("Unknown Name"),
+               description = config_["dotplug"]["description"].value_or<std::string>(""),
+               author = config_["dotplug"]["author"].value_or<std::string>("");
+    const auto dependencies = get_dependencies();
 
-    std::cout << (!prefix.empty() ? "[" + prefix + "] " : "") << name << ":"
-              << "\n";
+    std::cout << (!prefix.empty() ? "[" + prefix + "] " : "") << name << ":\n";
     if (!description.empty())
         std::cout << "        Description: " << description << "\n";
     if (!author.empty())
         std::cout << "        Author: " << author << "\n";
 
     std::cout << "        Dependencies: ";
-    for (std::string &i : dependencies)
+    for (const auto &i : dependencies)
         std::cout << i << ", ";
     std::cout << "\n";
 }

--- a/src/utils/format_check.cpp
+++ b/src/utils/format_check.cpp
@@ -10,6 +10,6 @@
  * @return true if the string contains `://`, false if not.
  */
 bool is_valid_url() {
-    size_t pos = ctx->name.find("://");
+    const auto pos = ctx->name.find("://");
     return (pos != std::string::npos) && (pos < 10);
 }

--- a/src/utils/symlinks.cpp
+++ b/src/utils/symlinks.cpp
@@ -33,7 +33,7 @@ int remove_all_symlinks() {
 
     for (const auto &dep_name : dependencies) {
         const auto dep = active_config.get_dependency(dep_name);
-		const auto dst = dep.at("destination");
+        const auto dst = dep.at("destination");
 
         if (!fs::exists(dst)) {
             std::cout << "[ERROR] Couldn't find the destination.\n";
@@ -49,7 +49,7 @@ int remove_all_symlinks() {
                 continue;
         }
 
-		fs::remove(dst);
+        fs::remove(dst);
     }
 
     fs::remove(config_path + "current");

--- a/src/utils/symlinks.cpp
+++ b/src/utils/symlinks.cpp
@@ -3,11 +3,12 @@
 #include <iostream>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 #include "context.hpp"
 #include "settings.hpp"
 #include "utils/config.hpp"
+
+namespace fs = std::filesystem;
 
 /* @brief Removes every active symlink from the config!
  *
@@ -19,27 +20,28 @@
 int remove_all_symlinks() {
     std::string active_config_name;
 
-    std::ifstream current(config_path + "current");
+    std::ifstream current{config_path + "current"};
     if (current.good()) {
         std::getline(current, active_config_name);
     } else {
-        std::cerr << "There is no active config!" << std::endl;
+        std::cerr << "There is no active config!\n";
         return 1;
     }
 
-    const Config active_config = Config(active_config_name);
-    const std::vector<std::string> dependencies = active_config.get_dependencies();
+    const Config active_config{active_config_name};
+    const auto dependencies = active_config.get_dependencies();
 
-    for (std::string dep_name : dependencies) {
-        std::unordered_map<std::string, std::string> dep = active_config.get_dependency(dep_name);
+    for (const auto &dep_name : dependencies) {
+        const auto dep = active_config.get_dependency(dep_name);
+		const auto dst = dep.at("destination");
 
-        if (!std::filesystem::exists(dep["destination"])) {
-            std::cout << "[ERROR] Couldn't find the destination." << std::endl;
+        if (!fs::exists(dst)) {
+            std::cout << "[ERROR] Couldn't find the destination.\n";
             return 1;
         }
 
-        if (!std::filesystem::is_symlink(dep["destination"]) && ctx->forced == false) {
-            std::cout << "[WARNING] " << dep["destination"] << "isn't a symlink! Want to delete it? (y/N)";
+        if (!fs::is_symlink(dst) && ctx->forced == false) {
+            std::cout << "[WARNING] " << dst << "isn't a symlink! Want to delete it? (y/N)";
             std::string choice;
             std::getline(std::cin, choice);
 
@@ -47,14 +49,9 @@ int remove_all_symlinks() {
                 continue;
         }
 
-        std::error_code err;
-        bool removed = std::filesystem::remove(dep["destination"], err);
-        if (!removed || err) {
-            std::cout << "Oh no, there was an error :<\n" << err.message() << std::endl;
-            return 1;
-        }
+		fs::remove(dst);
     }
 
-    std::filesystem::remove(config_path + "current");
+    fs::remove(config_path + "current");
     return 0;
 }


### PR DESCRIPTION
it's in the title; i didn't get to every file yet, but here's a rundown:
- promote encapsulation: don't access public members of objects (just like in the java days of learning)
  - solution: make getter methods like `Config::name()` and `Config::config()`, which shouldn't be there because callers having to deal with a `toml::table` makes their code more complicated. we should just have a getter called `dependency_is_table(...)` for `validator.cpp`
- use `auto`, `const`, and references (`&`) as much as possible
  - especially `auto` for variable declarations with long typenames
  - i also started liking the `auto function(...) -> return_type` declaration syntax, clearly inspired by modern languages. this is very subjective so lmk what you think
- use brace-initializers for object constructor calls. mostly subjective, but this helps me separate normal function/method calls from constructors, especially when syntax highlighting isn't available.
- refactor functions that just make use of an object reference to just be a method of that object's class
  - `Config::print() -> void` instead of `void print_config(const Config &)`
  - `Config::validate() -> ValidationResult` instead of `ValidationResult validator(const Config &)`
- use short, clear namespace aliases when it would otherwise be kind of long
  - `namespace fs = std::filesystem; fs::exists(...)` over `std::filesystem::exists(...)`
- use `'\n'` over `std::endl`. it's less code, and `std::endl` does more than insert a newline.
- use the throwing variants of `std::filesystem` functions, it's less code, and all you currently do with errors is print them anyway. let them throw and we can catch everything in `main` and display a generic error message.
- always use `std::vector::emplace_back` over `push_back`, it constructs objects inside the vector instead of having to call the copy constructor which has more overhead

misc changes:
- ci: went back to `push: [main]` and `pull_request: [main]` because 2 jobs turned into 4 runs which just bugged me
- formatting change: `AlignConsecutiveAssignments: Consecutive`, since i noticed you did this manually in `settings.hpp` before i joined the project

if there are any style changes you don't agree with we can discuss!