### PR TITLE
Improve CI speed by removing `man-db` apt post-install hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Prevent "Processing triggers for man-db" post-install hook
+        run: sudo rm /var/lib/man-db/auto-update
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -47,13 +50,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Prevent "Processing triggers for man-db" post-install hook
+        run: sudo rm /var/lib/man-db/auto-update
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             python3-pip \
             python3-setuptools \
-            ninja-build 
+            ninja-build
 
       - name: Install Conan and Meson
         run: pip3 install --upgrade conan meson


### PR DESCRIPTION
as the title states, i discovered this new strat :money_mouth_face: 

results:

<img width="353" height="64" alt="image" src="https://github.com/user-attachments/assets/6ba829d7-cd15-44fb-a179-06c644a2e185" />
